### PR TITLE
fix(bulk-processor): handle HTTP 413 from OpenSearch without killing the task [OC-5370]

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/opensearch/BulkProcessor.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/BulkProcessor.java
@@ -47,6 +47,7 @@ import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.core.rest.RestStatus;
 
 import org.slf4j.Logger;
@@ -505,6 +506,21 @@ public class BulkProcessor {
                         }
                     }
                     return response;
+                } catch (final OpenSearchStatusException e) {
+                    if (e.status() == RestStatus.REQUEST_ENTITY_TOO_LARGE) {
+                        // HTTP 413: the bulk payload exceeded OpenSearch's http.max_content_length limit.
+                        // Retrying the same batch will not help — the payload size won't change.
+                        // This is most likely caused by a rebalance flush spike where a task temporarily
+                        // absorbed extra partitions. The task-watcher will restart the task automatically.
+                        LOGGER.error(
+                                "Bulk request for batch {} of {} records rejected with 413 Request Entity Too Large."
+                                        + " Batch payload exceeded OpenSearch http.max_content_length limit."
+                                        + " Consider lowering batch.size or max.buffered.records.",
+                                batchId, batch.size(), e);
+                        throw new ConnectException("Bulk request rejected with 413 Request Entity Too Large", e);
+                    }
+                    LOGGER.error("Failed to send bulk request from batch {} of {} records", batchId, batch.size(), e);
+                    throw new RetriableError(e);
                 } catch (final IOException e) {
                     LOGGER.error("Failed to send bulk request from batch {} of {} records", batchId, batch.size(), e);
                     throw new RetriableError(e);


### PR DESCRIPTION
## Summary

- Catches `OpenSearchStatusException` explicitly in `BulkTask.execute()` alongside the existing `IOException` catch
- HTTP 413 → throws a `ConnectException` with a clear log message (no retries, since retrying the same payload won't help); the task-watcher can now match the error string and restart the task automatically
- Any other `OpenSearchStatusException` status code → wraps as `RetriableError` so existing retry/backoff logic applies

## Root cause

`OpenSearchStatusException` is a `RuntimeException`, not an `IOException`. It was falling through the existing `catch (IOException e)` block, exiting the `callWithRetry` lambda as an unhandled exception, and being classified as non-repeatable by `RetryUtil` — instantly killing the task with zero retries.

On 2026-03-02 this surfaced as a 413 caused by a rebalance flush spike: tasks 8 & 9 failed, `task-1` absorbed 24 partitions, and its rebalance-triggered flush produced a bulk payload that exceeded the OpenSearch `http.max_content_length` limit. The task died and required manual restart.

## Changes

`BulkProcessor.java` — `BulkTask.execute()`:
- Added `import org.opensearch.OpenSearchStatusException`
- New `catch (OpenSearchStatusException e)` block before the existing `catch (IOException e)`
  - 413 → `ConnectException` with descriptive log
  - other status codes → `RetriableError` (retried with backoff as before)

## Test plan

- [ ] `./gradlew test` passes (no existing tests broken)
- [ ] Integration test: produce a document large enough to trigger 413, confirm task dies with `ConnectException: Bulk request rejected with 413 Request Entity Too Large` rather than `Non-repeatable exception trown by bulk processing`
- [ ] Confirm non-413 `OpenSearchStatusException` (e.g. 503) is still retried

🤖 Generated with [Claude Code](https://claude.com/claude-code)